### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/Nantes.podspec
+++ b/Nantes.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Nantes'
-  s.version          = '0.1.3'
+  s.version          = '0.1.4'
   s.summary          = 'A swift replacement of TTTAttributedLabel'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Jira: [CXIOS-7866](https://jira.tenkasu.net/browse/CXIOS-7866)

### Background
<!-- In contrast to the description in the Jira ticket this should provide as much technical background as possible -->
In preparation for the CR iOS 4.19.0 release, we need to bump the versions for the in-house libraries that were updated for the current release.

### What has been done?
1. Bumped version to `0.1.4`

### How to test?
1. Make sure `*.podspec` file was updated with the correct version
2. Make sure CI passes

### Checklist
<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [x] I've run tests before opening PR
- [ ] I've written tests where necessary
- [x] I haven't introduced new warnings
- [ ] I have provided guiding annotations for reviewers

[Reviewer Guidelines](https://github.com/crunchyroll/ios-resources/blob/master/CODE_REVIEW_GUIDELINES.md)
